### PR TITLE
Flag Feature / Enhancement

### DIFF
--- a/core/src/org/ice1000/jimgui/flag/Flag.java
+++ b/core/src/org/ice1000/jimgui/flag/Flag.java
@@ -1,0 +1,83 @@
+package org.ice1000.jimgui.flag;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.List;
+
+public interface Flag {
+    int get();
+
+    /**
+     *
+     * @param flag to check for
+     * @param flags to check if flag is contained within
+     * @return boolean true of flag was found
+     */
+    static boolean hasFlag(int flag, Flag... flags) {
+        for (int i = 0; i < flags.length; i++) {
+            Flag value = flags[i];
+            if (value.get() == flag) return true;
+        }
+        return false;
+    }
+
+    // Slot enum[0], emum[1] for flags should be nothing and no flag found
+
+    /**
+     * This method assumes that all Flag.Type classes have a enum at position 0
+     * labeled NoSuchFlag that takes the default or nothing value for error
+     * prevention.
+     *
+     * @param enumType class that and enum type that extends Flag
+     * @param flag the flag to lookup
+     * @param <E> the Flag which extends Enum
+     * @return the Flag which is the flag int value
+     */
+    static <E extends Flag> E reverseLookup(Class<E> enumType, int flag) {
+        E[] enumConstants = enumType.getEnumConstants();
+        for (int i = 1; i < enumConstants.length; i++) {
+            E enumConstant = enumConstants[i];
+            int flagConstant = enumConstant.get();
+            if (flagConstant == flag) return enumConstant;
+        }
+        return enumConstants[0];
+    }
+
+    /**
+     * This method assumes that all Flag.Type classes have a enum at position 0
+     * labeled NoSuchFlag that takes the default or nothing value for error
+     * prevention.
+     *
+     * @param enumType class that and enum type that extends Flag
+     * @param flags the flags to lookup
+     * @param <E> the Flag which extends Enum
+     * @return the flags which is the flags int values
+     */
+    static <E extends Flag> E[] getAsFlags(Class<E> enumType, int flags) {
+        List<E> setFlags = new ArrayList<>();
+        E[] enumConstants = enumType.getEnumConstants();
+        for (int i = 1; i < enumConstants.length; i++) {
+            E enumConstant = enumConstants[i];
+            int flagConstant = enumConstant.get();
+            boolean flagSet = (flags & flagConstant) != 0;
+            if (flagSet) setFlags.add(enumConstant);
+        }
+        final E[] a = (E[]) Array.newInstance(enumType, setFlags.size());
+        setFlags.toArray(a);
+        return a;
+    }
+
+    /**
+     *
+     * @param flagSelection Flags
+     * @return value of all the flags set
+     */
+    static int getAsValue(Flag... flagSelection){
+        int flags = 0;
+        for (int i = 0; i < flagSelection.length; i++) {
+            Flag flag = flagSelection[i];
+            flags |= flag.get();
+        }
+        return flags;
+    }
+}

--- a/core/src/org/ice1000/jimgui/flag/JImBackendFlags.java
+++ b/core/src/org/ice1000/jimgui/flag/JImBackendFlags.java
@@ -5,6 +5,7 @@ package org.ice1000.jimgui.flag;
  * @since v0.1
  */
 public interface JImBackendFlags {
+	int Nothing = 0;
 	/** Back-end supports and has a connected gamepad. */
 	int HasGamepad = 1;
 	/** Back-end supports reading GetMouseCursor() to change the OS cursor shape. */
@@ -14,4 +15,31 @@ public interface JImBackendFlags {
 	 * (only used if {@link JImConfigFlags#NavEnableSetMousePos} is set).
 	 */
 	int HasSetMousePos = 1 << 2;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(JImBackendFlags.Nothing),
+		/** @see JImBackendFlags#Nothing */
+		Nothing(JImBackendFlags.Nothing),
+		/** @see JImBackendFlags#HasGamepad */
+		HasGamepad(JImBackendFlags.HasGamepad),
+		/** @see JImBackendFlags#HasMouseCursors */
+		HasMouseCursors(JImBackendFlags.HasMouseCursors),
+		/** @see JImBackendFlags#HasSetMousePos */
+		HasSetMousePos(JImBackendFlags.HasSetMousePos);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImColorEditFlags.java
+++ b/core/src/org/ice1000/jimgui/flag/JImColorEditFlags.java
@@ -140,4 +140,75 @@ public interface JImColorEditFlags {
 	int DataTypeMask = Uint8 | Float;
 	int PickerMask = PickerHueWheel | PickerHueBar;
 	int OptionsDefault = Uint8 | RGB | PickerHueBar;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(JImColorEditFlags.Nothing),
+		Nothing(JImColorEditFlags.Nothing),
+		/** @see JImColorEditFlags#NoAlpha */
+		NoAlpha(JImColorEditFlags.NoAlpha),
+		/** @see JImColorEditFlags#NoPicker */
+		NoPicker(JImColorEditFlags.NoPicker),
+		/** @see JImColorEditFlags#NoOptions */
+		NoOptions(JImColorEditFlags.NoOptions),
+		/** @see JImColorEditFlags#NoSmallPreview */
+		NoSmallPreview(JImColorEditFlags.NoSmallPreview),
+		/** @see JImColorEditFlags#NoInputs */
+		NoInputs(JImColorEditFlags.NoInputs),
+		/** @see JImColorEditFlags#NoTooltip */
+		NoTooltip(JImColorEditFlags.NoTooltip),
+		/** @see JImColorEditFlags#NoLabel */
+		NoLabel(JImColorEditFlags.NoLabel),
+		/** @see JImColorEditFlags#NoSidePreview */
+		NoSidePreview(JImColorEditFlags.NoSidePreview),
+		/** @see JImColorEditFlags#NoDragDrop */
+		NoDragDrop(JImColorEditFlags.NoDragDrop),
+
+		// user options
+
+		/** @see JImColorEditFlags#AlphaBar */
+		AlphaBar(JImColorEditFlags.AlphaBar),
+		/** @see JImColorEditFlags#AlphaPreview */
+		AlphaPreview(JImColorEditFlags.AlphaPreview),
+		/** @see JImColorEditFlags#AlphaPreviewHalf */
+		AlphaPreviewHalf(JImColorEditFlags.AlphaPreviewHalf),
+		/** @see JImColorEditFlags#HDR */
+		HDR(JImColorEditFlags.HDR),
+		/** @see JImColorEditFlags#RGB */
+		RGB(JImColorEditFlags.RGB),
+		/** @see JImColorEditFlags#HSV */
+		HSV(JImColorEditFlags.HSV),
+		/** @see JImColorEditFlags#HEX */
+		HEX(JImColorEditFlags.HEX),
+		/** @see JImColorEditFlags#Uint8 */
+		Uint8(JImColorEditFlags.Uint8),
+		/** @see JImColorEditFlags#Float */
+		Float(JImColorEditFlags.Float),
+		/** @see JImColorEditFlags#PickerHueBar */
+		PickerHueBar(JImColorEditFlags.PickerHueBar),
+		/** @see JImColorEditFlags#PickerHueWheel */
+		PickerHueWheel(JImColorEditFlags.PickerHueWheel),
+
+
+		// [Internal] Masks
+
+		InputsMask(JImColorEditFlags.RGB | JImColorEditFlags.HSV | JImColorEditFlags.HEX ),
+		DataTypeMask(JImColorEditFlags.Uint8 | JImColorEditFlags.Float),
+		PickerMask (JImColorEditFlags.PickerHueWheel | JImColorEditFlags.PickerHueBar),
+		OptionsDefault(JImColorEditFlags.Uint8 | JImColorEditFlags.RGB | JImColorEditFlags.PickerHueBar);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImComboFlags.java
+++ b/core/src/org/ice1000/jimgui/flag/JImComboFlags.java
@@ -27,4 +27,40 @@ public interface JImComboFlags {
 	/** Display only a square arrow button */
 	int NoPreview = 1 << 6;
 	int HeightMask_ = HeightSmall | HeightRegular | HeightLarge | HeightLargest;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(JImComboFlags.Nothing),
+		Nothing(JImComboFlags.Nothing),
+		/** @see JImComboFlags#PopupAlignLeft */
+		PopupAlignLeft(JImComboFlags.PopupAlignLeft),
+		/** @see JImComboFlags#HeightSmall */
+		HeightSmall(JImComboFlags.HeightSmall),
+		/** @see JImComboFlags#HeightRegular */
+		HeightRegular(JImComboFlags.HeightRegular),
+		/** @see JImComboFlags#HeightLarge */
+		HeightLarge(JImComboFlags.HeightLarge),
+		/** @see JImComboFlags#HeightLargest */
+		HeightLargest(JImComboFlags.HeightLargest),
+		/** @see JImComboFlags#NoArrowButton */
+		NoArrowButton(JImComboFlags.NoArrowButton),
+		/** @see JImComboFlags#NoPreview */
+		NoPreview(JImComboFlags.NoPreview),
+
+		HeightMask_(JImComboFlags.HeightSmall | JImComboFlags.HeightRegular | JImComboFlags.HeightLarge | JImComboFlags.HeightLargest);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImCondition.java
+++ b/core/src/org/ice1000/jimgui/flag/JImCondition.java
@@ -7,6 +7,7 @@ package org.ice1000.jimgui.flag;
  * @since v0.1
  */
 public interface JImCondition {
+	int Nothing = 0;
 	/** Set the variable */
 	int Always = 1;
 	/** Set the variable once per runtime session (only the first call with succeed) */
@@ -15,4 +16,32 @@ public interface JImCondition {
 	int FirstUseEver = 1 << 2;
 	/** Set the variable if the object/window is appearing after being hidden/inactive (or the first time) */
 	int Appearing = 1 << 3;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(JImCondition.Nothing),
+		Nothing(JImCondition.Nothing),
+		/** @see JImCondition#Always */
+		Always(JImCondition.Always),
+		/** @see JImCondition#Once */
+		Once(JImCondition.Once),
+		/** @see JImCondition#FirstUseEver */
+		FirstUseEver(JImCondition.FirstUseEver),
+		/** @see JImCondition#Appearing */
+		Appearing(JImCondition.Appearing);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImConfigFlags.java
+++ b/core/src/org/ice1000/jimgui/flag/JImConfigFlags.java
@@ -7,6 +7,7 @@ import org.ice1000.jimgui.JImGuiIOGen;
  * @since v0.1
  */
 public interface JImConfigFlags {
+	int Nothing = 0;
 	/**
 	 * Master keyboard navigation enable flag.
 	 * initNewFrame() will automatically fill getIO().NavInputs[] based on getIO().KeysDown[].
@@ -42,4 +43,40 @@ public interface JImConfigFlags {
 	int IsSRGB = 1 << 20;
 	/** Application is using a touch screen instead of a mouse. */
 	int IsTouchScreen = 1 << 21;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(JImConfigFlags.Nothing),
+		Nothing(JImConfigFlags.Nothing),
+		/** @see JImConfigFlags#NavEnableKeyboard */
+		NavEnableKeyboard(JImConfigFlags.NavEnableKeyboard),
+		/** @see JImConfigFlags#NavEnableGamepad */
+		NavEnableGamepad(JImConfigFlags.NavEnableGamepad),
+		/** @see JImConfigFlags#NavEnableSetMousePos */
+		NavEnableSetMousePos(JImConfigFlags.NavEnableSetMousePos),
+		/** @see JImConfigFlags#NavNoCaptureKeyboard */
+		NavNoCaptureKeyboard(JImConfigFlags.NavNoCaptureKeyboard),
+		/** @see JImConfigFlags#NoMouse */
+		NoMouse(JImConfigFlags.NoMouse),
+		/** @see JImConfigFlags#NoMouseCursorChange */
+		NoMouseCursorChange(JImConfigFlags.NoMouseCursorChange),
+		/** @see JImConfigFlags#IsSRGB */
+		IsSRGB(JImConfigFlags.IsSRGB),
+		/** @see JImConfigFlags#IsTouchScreen */
+		IsTouchScreen(JImConfigFlags.IsTouchScreen);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImDirection.java
+++ b/core/src/org/ice1000/jimgui/flag/JImDirection.java
@@ -10,4 +10,33 @@ public interface JImDirection {
 	int Right = 1;
 	int Up = 2;
 	int Down = 3;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(JImDirection.None),
+		/** @see JImDirection#None */
+		None(JImDirection.None),
+		/** @see JImDirection#Left */
+		Left(JImDirection.Left),
+		/** @see JImDirection#Right */
+		Right(JImDirection.Right),
+		/** @see JImDirection#Up */
+		Up(JImDirection.Up),
+		/** @see JImDirection#Down */
+		Down(JImDirection.Down);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImDrawCornerFlags.java
+++ b/core/src/org/ice1000/jimgui/flag/JImDrawCornerFlags.java
@@ -7,6 +7,7 @@ package org.ice1000.jimgui.flag;
  * @since v0.1
  */
 public interface JImDrawCornerFlags {
+	int Nothing = 0;
 	/** 0x1 */
 	int TopLeft = 1;
 	/** 0x2 */
@@ -28,4 +29,42 @@ public interface JImDrawCornerFlags {
 	 * (= all bits sets) instead of this, as a convenience
 	 */
 	int All = 0xF;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(JImDrawCornerFlags.Nothing),
+		Nothing(JImDrawCornerFlags.Nothing),
+		/** @see JImDrawCornerFlags#TopLeft */
+		TopLeft(JImDrawCornerFlags.TopLeft),
+		/** @see JImDrawCornerFlags#TopRight */
+		TopRight(JImDrawCornerFlags.TopRight),
+		/** @see JImDrawCornerFlags#BotLeft */
+		BotLeft(JImDrawCornerFlags.BotLeft),
+		/** @see JImDrawCornerFlags#BotRight */
+		BotRight(JImDrawCornerFlags.BotRight),
+		/** @see JImDrawCornerFlags#Top */
+		Top(JImDrawCornerFlags.Top),
+		/** @see JImDrawCornerFlags#Bot */
+		Bot(JImDrawCornerFlags.Bot),
+		/** @see JImDrawCornerFlags#Left */
+		Left(JImDrawCornerFlags.Left),
+		/** @see JImDrawCornerFlags#Right */
+		Right(JImDrawCornerFlags.Right),
+		/** @see JImDrawCornerFlags#All */
+		All(JImDrawCornerFlags.All);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImDrawListFlags.java
+++ b/core/src/org/ice1000/jimgui/flag/JImDrawListFlags.java
@@ -8,4 +8,28 @@ public interface JImDrawListFlags {
 	int Nothing = 0;
 	int AntiAliasedLines = 1;
 	int AntiAliasedFill = 1 << 1;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(JImDrawListFlags.Nothing),
+		Nothing(JImDrawListFlags.Nothing),
+		/** @see JImDrawListFlags#AntiAliasedLines */
+		AntiAliasedLines(JImDrawListFlags.AntiAliasedLines),
+		/** @see JImDrawListFlags#AntiAliasedFill */
+		AntiAliasedFill(JImDrawListFlags.AntiAliasedFill);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImFocusedFlags.java
+++ b/core/src/org/ice1000/jimgui/flag/JImFocusedFlags.java
@@ -7,6 +7,7 @@ package org.ice1000.jimgui.flag;
  * @since v0.1
  */
 public interface JImFocusedFlags {
+	int Nothing = 0;
 	int Default = 0;
 	/** {@link org.ice1000.jimgui.JImGuiGen#isWindowFocused}: Return true if any children of the window is focused */
 	int ChildWindows = 1;
@@ -15,4 +16,34 @@ public interface JImFocusedFlags {
 	/** {@link org.ice1000.jimgui.JImGuiGen#isWindowFocused}: Return true if any window is focused */
 	int AnyWindow = 1 << 2;
 	int RootAndChildWindows = RootWindow | ChildWindows;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(JImFocusedFlags.Nothing),
+		Nothing(JImFocusedFlags.Nothing),
+		/** @see JImFocusedFlags#Default */
+		Default(JImFocusedFlags.Default),
+		/** @see JImFocusedFlags#ChildWindows */
+		ChildWindows(JImFocusedFlags.ChildWindows),
+		/** @see JImFocusedFlags#RootWindow */
+		RootWindow(JImFocusedFlags.RootWindow),
+		/** @see JImFocusedFlags#AnyWindow */
+		AnyWindow(JImFocusedFlags.AnyWindow),
+		/** @see JImFocusedFlags#RootAndChildWindows */
+		RootAndChildWindows(JImFocusedFlags.RootAndChildWindows);
+		
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImFontAtlasFlags.java
+++ b/core/src/org/ice1000/jimgui/flag/JImFontAtlasFlags.java
@@ -5,6 +5,31 @@ package org.ice1000.jimgui.flag;
  * @since v0.1
  */
 public interface JImFontAtlasFlags {
+	int Nothing = 0;
 	int NoPowerOfTwoHeight = 1;
 	int NoMouseCursors = 1 << 1;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison. 0 Used to prevent ImGui errors from
+		 * unexpected results
+		 */
+		NoSuchFlag(JImFontAtlasFlags.Nothing),
+		Nothing(JImFontAtlasFlags.Nothing),
+		/** @see JImFontAtlasFlags#NoPowerOfTwoHeight */
+		NoPowerOfTwoHeight(JImFontAtlasFlags.NoPowerOfTwoHeight),
+		/** @see JImFontAtlasFlags#NoMouseCursors */
+		NoMouseCursors(JImFontAtlasFlags.NoMouseCursors);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImHoveredFlags.java
+++ b/core/src/org/ice1000/jimgui/flag/JImHoveredFlags.java
@@ -9,6 +9,7 @@ package org.ice1000.jimgui.flag;
  * @since v0.1
  */
 public interface JImHoveredFlags {
+	int Nothing = 0;
 	/**
 	 * Return true if directly over the item/window,
 	 * not obstructed by another window,
@@ -33,4 +34,44 @@ public interface JImHoveredFlags {
 	int AllowWhenDisabled = 1 << 7;
 	int RectOnly = AllowWhenBlockedByPopup | AllowWhenBlockedByActiveItem | AllowWhenOverlapped;
 	int RootAndChildWindows = RootWindow | ChildWindows;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(JImHoveredFlags.Nothing),
+		Nothing(JImHoveredFlags.Nothing),
+		/** @see JImHoveredFlags#Default */
+		Default(JImHoveredFlags.Default),
+		/** @see JImHoveredFlags#ChildWindows */
+		ChildWindows(JImHoveredFlags.ChildWindows),
+		/** @see JImHoveredFlags#RootWindow */
+		RootWindow(JImHoveredFlags.RootWindow),
+		/** @see JImHoveredFlags#AnyWindow */
+		AnyWindow(JImHoveredFlags.AnyWindow),
+		/** @see JImHoveredFlags#AllowWhenBlockedByPopup */
+		AllowWhenBlockedByPopup(JImHoveredFlags.AllowWhenBlockedByPopup),
+		/** @see JImHoveredFlags#AllowWhenBlockedByActiveItem */
+		AllowWhenBlockedByActiveItem(JImHoveredFlags.AllowWhenBlockedByActiveItem),
+		/** @see JImHoveredFlags#AllowWhenOverlapped */
+		AllowWhenOverlapped(JImHoveredFlags.AllowWhenOverlapped),
+		/** @see JImHoveredFlags#AllowWhenDisabled */
+		AllowWhenDisabled(JImHoveredFlags.AllowWhenDisabled),
+		/** @see JImHoveredFlags#RectOnly */
+		RectOnly(JImHoveredFlags.RectOnly),
+		/** @see JImHoveredFlags#RootAndChildWindows */
+		RootAndChildWindows(JImHoveredFlags.RootAndChildWindows);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImInputTextFlags.java
+++ b/core/src/org/ice1000/jimgui/flag/JImInputTextFlags.java
@@ -42,4 +42,60 @@ public interface JImInputTextFlags {
 	int NoUndoRedo = 1 << 16;
 	/** Allow 0123456789*.+-/eE (Scientific notation input) */
 	int CharsScientific = 1 << 17;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(JImInputTextFlags.Nothing),
+		Nothing(JImInputTextFlags.Nothing),
+		/** @see JImInputTextFlags#CharsDecimal */
+		CharsDecimal(JImInputTextFlags.CharsDecimal),
+		/** @see JImInputTextFlags#CharsHexadecimal */
+		CharsHexadecimal(JImInputTextFlags.CharsHexadecimal),
+		/** @see JImInputTextFlags#CharsUppercase */
+		CharsUppercase(JImInputTextFlags.CharsUppercase),
+		/** @see JImInputTextFlags#CharsNoBlank */
+		CharsNoBlank(JImInputTextFlags.CharsNoBlank),
+		/** @see JImInputTextFlags#AutoSelectAll */
+		AutoSelectAll(JImInputTextFlags.AutoSelectAll),
+		/** @see JImInputTextFlags#EnterReturnsTrue */
+		EnterReturnsTrue(JImInputTextFlags.EnterReturnsTrue),
+		/** @see JImInputTextFlags#CallbackCompletion */
+		CallbackCompletion(JImInputTextFlags.CallbackCompletion),
+		/** @see JImInputTextFlags#CallbackHistory */
+		CallbackHistory(JImInputTextFlags.CallbackHistory),
+		/** @see JImInputTextFlags#CallbackAlways */
+		CallbackAlways(JImInputTextFlags.CallbackAlways),
+		/** @see JImInputTextFlags#CallbackCharFilter */
+		CallbackCharFilter(JImInputTextFlags.CallbackCharFilter),
+		/** @see JImInputTextFlags#AllowTabInput */
+		AllowTabInput(JImInputTextFlags.AllowTabInput),
+		/** @see JImInputTextFlags#CtrlEnterForNewLine */
+		CtrlEnterForNewLine(JImInputTextFlags.CtrlEnterForNewLine),
+		/** @see JImInputTextFlags#NoHorizontalScroll */
+		NoHorizontalScroll(JImInputTextFlags.NoHorizontalScroll),
+		/** @see JImInputTextFlags#AlwaysInsertMode */
+		AlwaysInsertMode(JImInputTextFlags.AlwaysInsertMode),
+		/** @see JImInputTextFlags#ReadOnly */
+		ReadOnly(JImInputTextFlags.ReadOnly),
+		/** @see JImInputTextFlags#Password */
+		Password(JImInputTextFlags.Password),
+		/** @see JImInputTextFlags#NoUndoRedo */
+		NoUndoRedo(JImInputTextFlags.NoUndoRedo),
+		/** @see JImInputTextFlags#CharsScientific */
+		CharsScientific(JImInputTextFlags.CharsScientific);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImMouseIndexes.java
+++ b/core/src/org/ice1000/jimgui/flag/JImMouseIndexes.java
@@ -10,4 +10,33 @@ public interface JImMouseIndexes {
 	int Middle = 2;
 	int ExtraA = 3;
 	int ExtraB = 4;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(-1),
+		/** @see JImMouseIndexes#Left */
+		Left(JImMouseIndexes.Left),
+		/** @see JImMouseIndexes#Right */
+		Right(JImMouseIndexes.Right),
+		/** @see JImMouseIndexes#Middle */
+		Middle(JImMouseIndexes.Middle),
+		/** @see JImMouseIndexes#ExtraA */
+		ExtraA(JImMouseIndexes.ExtraA),
+		/** @see JImMouseIndexes#ExtraB */
+		ExtraB(JImMouseIndexes.ExtraB);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImSelectableFlags.java
+++ b/core/src/org/ice1000/jimgui/flag/JImSelectableFlags.java
@@ -12,4 +12,30 @@ public interface JImSelectableFlags {
 	int SpanAllColumns = 1 << 1;
 	/** Generate press events on double clicks too */
 	int AllowDoubleClick = 1 << 2;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(JImSelectableFlags.Nothing),
+		Nothing(JImSelectableFlags.Nothing),
+		/** @see JImSelectableFlags#DontClosePopups */
+		DontClosePopups(JImSelectableFlags.DontClosePopups),
+		/** @see JImSelectableFlags#SpanAllColumns */
+		SpanAllColumns(JImSelectableFlags.SpanAllColumns),
+		/** @see JImSelectableFlags#AllowDoubleClick */
+		AllowDoubleClick(JImSelectableFlags.AllowDoubleClick);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImTabBarFlags.java
+++ b/core/src/org/ice1000/jimgui/flag/JImTabBarFlags.java
@@ -23,4 +23,44 @@ public interface JImTabBarFlags {
 	int FittingPolicyScroll = 1 << 7;
 	int FittingPolicyMask = FittingPolicyResizeDown | FittingPolicyScroll;
 	int FittingPolicyDefault = FittingPolicyResizeDown;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(JImTabBarFlags.None),
+		None(JImTabBarFlags.None),
+		/** @see JImTabBarFlags#Reorderable */
+		Reorderable(JImTabBarFlags.Reorderable),
+		/** @see JImTabBarFlags#AutoSelectNewTabs */
+		AutoSelectNewTabs(JImTabBarFlags.AutoSelectNewTabs),
+		/** @see JImTabBarFlags#TabListPopupButton */
+		TabListPopupButton(JImTabBarFlags.TabListPopupButton),
+		/** @see JImTabBarFlags#NoCloseWithMiddleMouseButton */
+		NoCloseWithMiddleMouseButton(JImTabBarFlags.NoCloseWithMiddleMouseButton),
+		/** @see JImTabBarFlags#NoTabListScrollingButtons */
+		NoTabListScrollingButtons(JImTabBarFlags.NoTabListScrollingButtons),
+		/** @see JImTabBarFlags#NoTooltip */
+		NoTooltip(JImTabBarFlags.NoTooltip),
+		/** @see JImTabBarFlags#FittingPolicyResizeDown */
+		FittingPolicyResizeDown(JImTabBarFlags.FittingPolicyResizeDown),
+		/** @see JImTabBarFlags#FittingPolicyScroll */
+		FittingPolicyScroll(JImTabBarFlags.FittingPolicyScroll),
+		/** @see JImTabBarFlags#FittingPolicyMask */
+		FittingPolicyMask(JImTabBarFlags.FittingPolicyMask),
+		/** @see JImTabBarFlags#FittingPolicyDefault */
+		FittingPolicyDefault(JImTabBarFlags.FittingPolicyDefault);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImTabItemFlags.java
+++ b/core/src/org/ice1000/jimgui/flag/JImTabItemFlags.java
@@ -9,4 +9,32 @@ public interface JImTabItemFlags {
     int SetSelected = 1 << 1;
     int NoCloseWithMiddleMouseButton = 1 << 2;
     int NoPushId = 1 << 3;
+
+    enum Type implements Flag {
+        /**
+         * Used for reverse lookup results and enum comparison.
+         * Return the Nothing or Default flag to prevent errors.
+         */
+        NoSuchFlag(JImTabItemFlags.None),
+        None(JImTabItemFlags.None),
+        /** @see JImTabItemFlags#UnsavedDocument */
+        UnsavedDocument(JImTabItemFlags.UnsavedDocument),
+        /** @see JImTabItemFlags#SetSelected */
+        SetSelected(JImTabItemFlags.SetSelected),
+        /** @see JImTabItemFlags#NoCloseWithMiddleMouseButton */
+        NoCloseWithMiddleMouseButton(JImTabItemFlags.NoCloseWithMiddleMouseButton),
+        /** @see JImTabItemFlags#NoPushId */
+        NoPushId(JImTabItemFlags.NoPushId);
+
+        public final int flag;
+
+        Type(int flag) {
+            this.flag = flag;
+        }
+
+        @Override
+        public int get() {
+            return flag;
+        }
+    }
 }

--- a/core/src/org/ice1000/jimgui/flag/JImTextEditFlags.java
+++ b/core/src/org/ice1000/jimgui/flag/JImTextEditFlags.java
@@ -42,4 +42,60 @@ public interface JImTextEditFlags {
 	int NoUndoRedo = 1 << 16;
 	/** Allow 0123456789.+*-/eE(Scientific notation input) */
 	int CharsScientific = 1 << 17;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(JImTextEditFlags.Nothing),
+		Nothing(JImTextEditFlags.Nothing),
+		/** @see JImTextEditFlags#CharsDecimal */
+		CharsDecimal(JImTextEditFlags.CharsDecimal),
+		/** @see JImTextEditFlags#CharsHexadecimal */
+		CharsHexadecimal(JImTextEditFlags.CharsHexadecimal),
+		/** @see JImTextEditFlags#CharsUppercase */
+		CharsUppercase(JImTextEditFlags.CharsUppercase),
+		/** @see JImTextEditFlags#CharsNoBlank */
+		CharsNoBlank(JImTextEditFlags.CharsNoBlank),
+		/** @see JImTextEditFlags#AutoSelectAll */
+		AutoSelectAll(JImTextEditFlags.AutoSelectAll),
+		/** @see JImTextEditFlags#EnterReturnsTrue */
+		EnterReturnsTrue(JImTextEditFlags.EnterReturnsTrue),
+		/** @see JImTextEditFlags#CallbackCompletion */
+		CallbackCompletion(JImTextEditFlags.CallbackCompletion),
+		/** @see JImTextEditFlags#CallbackHistory */
+		CallbackHistory(JImTextEditFlags.CallbackHistory),
+		/** @see JImTextEditFlags#CallbackAlways */
+		CallbackAlways(JImTextEditFlags.CallbackAlways),
+		/** @see JImTextEditFlags#CallbackCharFilter */
+		CallbackCharFilter(JImTextEditFlags.CallbackCharFilter),
+		/** @see JImTextEditFlags#AllowTabInput */
+		AllowTabInput(JImTextEditFlags.AllowTabInput),
+		/** @see JImTextEditFlags#CtrlEnterForNewLine */
+		CtrlEnterForNewLine(JImTextEditFlags.CtrlEnterForNewLine),
+		/** @see JImTextEditFlags#NoHorizontalScroll */
+		NoHorizontalScroll(JImTextEditFlags.NoHorizontalScroll),
+		/** @see JImTextEditFlags#AlwaysInsertMode */
+		AlwaysInsertMode(JImTextEditFlags.AlwaysInsertMode),
+		/** @see JImTextEditFlags#ReadOnly */
+		ReadOnly(JImTextEditFlags.ReadOnly),
+		/** @see JImTextEditFlags#Password */
+		Password(JImTextEditFlags.Password),
+		/** @see JImTextEditFlags#NoUndoRedo */
+		NoUndoRedo(JImTextEditFlags.NoUndoRedo),
+		/** @see JImTextEditFlags#CharsScientific */
+		CharsScientific(JImTextEditFlags.CharsScientific);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImTreeNodeFlags.java
+++ b/core/src/org/ice1000/jimgui/flag/JImTreeNodeFlags.java
@@ -7,6 +7,7 @@ import org.ice1000.jimgui.JImGuiGen;
  * @since v0.1
  */
 public interface JImTreeNodeFlags {
+	int Nothing = 0;
 	/** Draw as selected */
 	int Selected = 1;
 	/** Full colored frame (e.g. for {@link JImTreeNodeFlags#CollapsingHeader}) */
@@ -42,4 +43,50 @@ public interface JImTreeNodeFlags {
 	 */
 	int NavLeftJumpsBackHere = 1 << 13;
 	int CollapsingHeader = Framed | NoAutoOpenOnLog;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(JImTreeNodeFlags.Nothing),
+		Nothing(JImTreeNodeFlags.Nothing),
+		/** @see JImTreeNodeFlags#Selected */
+		Selected(JImTreeNodeFlags.Selected),
+		/** @see JImTreeNodeFlags#Framed */
+		Framed(JImTreeNodeFlags.Framed),
+		/** @see JImTreeNodeFlags#AllowItemOverlap */
+		AllowItemOverlap(JImTreeNodeFlags.AllowItemOverlap),
+		/** @see JImTreeNodeFlags#NoTreePushOnOpen */
+		NoTreePushOnOpen(JImTreeNodeFlags.NoTreePushOnOpen),
+		/** @see JImTreeNodeFlags#NoAutoOpenOnLog */
+		NoAutoOpenOnLog(JImTreeNodeFlags.NoAutoOpenOnLog),
+		/** @see JImTreeNodeFlags#DefaultOpen */
+		DefaultOpen(JImTreeNodeFlags.DefaultOpen),
+		/** @see JImTreeNodeFlags#OpenOnDoubleClick */
+		OpenOnDoubleClick(JImTreeNodeFlags.OpenOnDoubleClick),
+		/** @see JImTreeNodeFlags#OpenOnArrow */
+		OpenOnArrow(JImTreeNodeFlags.OpenOnArrow),
+		/** @see JImTreeNodeFlags#Leaf */
+		Leaf(JImTreeNodeFlags.Leaf),
+		/** @see JImTreeNodeFlags#Bullet */
+		Bullet(JImTreeNodeFlags.Bullet),
+		/** @see JImTreeNodeFlags#FramePadding */
+		FramePadding(JImTreeNodeFlags.FramePadding),
+		/** @see JImTreeNodeFlags#NavLeftJumpsBackHere */
+		NavLeftJumpsBackHere(JImTreeNodeFlags.NavLeftJumpsBackHere),
+		/** @see JImTreeNodeFlags#CollapsingHeader */
+		CollapsingHeader(JImTreeNodeFlags.CollapsingHeader);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/JImWindowFlags.java
+++ b/core/src/org/ice1000/jimgui/flag/JImWindowFlags.java
@@ -55,4 +55,66 @@ public interface JImWindowFlags {
 	 * @apiNote (only use on child that have no scrolling !)
 	 */
 	int NavFlattened = 1 << 23;
+
+	enum Type implements Flag {
+		/**
+		 * Used for reverse lookup results and enum comparison.
+		 * Return the Nothing or Default flag to prevent errors.
+		 */
+		NoSuchFlag(JImWindowFlags.Nothing),
+		Nothing(JImWindowFlags.Nothing),
+		/** @see JImWindowFlags#NoTitleBar */
+		NoTitleBar(JImWindowFlags.NoTitleBar),
+		/** @see JImWindowFlags#NoResize */
+		NoResize(JImWindowFlags.NoResize),
+		/** @see JImWindowFlags#NoMove */
+		NoMove(JImWindowFlags.NoMove),
+		/** @see JImWindowFlags#NoScrollbar */
+		NoScrollbar(JImWindowFlags.NoScrollbar),
+		/** @see JImWindowFlags#NoScrollWithMouse */
+		NoScrollWithMouse(JImWindowFlags.NoScrollWithMouse),
+		/** @see JImWindowFlags#NoCollapse */
+		NoCollapse(JImWindowFlags.NoCollapse),
+		/** @see JImWindowFlags#AlwaysAutoResize */
+		AlwaysAutoResize(JImWindowFlags.AlwaysAutoResize),
+		/** @see JImWindowFlags#NoSavedSettings */
+		NoSavedSettings(JImWindowFlags.NoSavedSettings),
+		/** @see JImWindowFlags#NoInputs */
+		NoInputs(JImWindowFlags.NoInputs),
+		/** @see JImWindowFlags#MenuBar */
+		MenuBar(JImWindowFlags.MenuBar),
+		/** @see JImWindowFlags#HorizontalScrollbar */
+		HorizontalScrollbar(JImWindowFlags.HorizontalScrollbar),
+		/** @see JImWindowFlags#NoFocusOnAppearing */
+		NoFocusOnAppearing(JImWindowFlags.NoFocusOnAppearing),
+		/** @see JImWindowFlags#NoBringToFrontOnFocus */
+		NoBringToFrontOnFocus(JImWindowFlags.NoBringToFrontOnFocus),
+		/** @see JImWindowFlags#AlwaysVerticalScrollbar */
+		AlwaysVerticalScrollbar(JImWindowFlags.AlwaysVerticalScrollbar),
+		/** @see JImWindowFlags#AlwaysHorizontalScrollbar */
+		AlwaysHorizontalScrollbar(JImWindowFlags.AlwaysHorizontalScrollbar),
+		/** @see JImWindowFlags#AlwaysUseWindowPadding */
+		AlwaysUseWindowPadding(JImWindowFlags.AlwaysUseWindowPadding),
+		/** @see JImWindowFlags#ResizeFromAnySide */
+		ResizeFromAnySide(JImWindowFlags.ResizeFromAnySide),
+		/** @see JImWindowFlags#NoNavInputs */
+		NoNavInputs(JImWindowFlags.NoNavInputs),
+		/** @see JImWindowFlags#NoNavFocus */
+		NoNavFocus(JImWindowFlags.NoNavFocus),
+		/** @see JImWindowFlags#NoNav */
+		NoNav(JImWindowFlags.NoNav),
+		/** @see JImWindowFlags#NavFlattened */
+		NavFlattened(JImWindowFlags.NavFlattened);
+
+		public final int flag;
+
+		Type(int flag) {
+			this.flag = flag;
+		}
+
+		@Override
+		public int get() {
+			return flag;
+		}
+	}
 }

--- a/core/src/org/ice1000/jimgui/flag/package-info.java
+++ b/core/src/org/ice1000/jimgui/flag/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * ImGui uses int flags by default. In addition to the FlagsClass.CONSTANTS
+ * provided by each interface a library user will find FlagClass.Type which
+ * are Enumerations that Implement the Flag interface and mirror the
+ * FlagClass.CONSTANTS to allow for object oriented programming and human
+ * readable reverse lookups which are useful for the developer to set
+ * flags easier. Flags.class has some helper methods for flags and numbers.
+ */
+package org.ice1000.jimgui.flag;

--- a/core/test/org/ice1000/jimgui/flag/FlagTest.java
+++ b/core/test/org/ice1000/jimgui/flag/FlagTest.java
@@ -1,0 +1,39 @@
+package org.ice1000.jimgui.flag;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FlagTest {
+
+    @Test
+    public void hasFlag() {
+        assertTrue(Flag.hasFlag(2, JImColorEditFlags.Type.NoAlpha, JImColorEditFlags.Type.NoPicker));
+    }
+
+    @Test
+    public void reverseLookup() {
+        assertEquals(JImColorEditFlags.Type.NoAlpha, Flag.reverseLookup(JImColorEditFlags.Type.class, 2));
+    }
+
+    @Test
+    public void getAsFlags() {
+        List<JImColorEditFlags.Type> flags = new ArrayList<>(2);
+        flags.add(JImColorEditFlags.Type.NoAlpha);
+        flags.add(JImColorEditFlags.Type.NoPicker);
+        JImColorEditFlags.Type[] asFlags = Flag.getAsFlags(JImColorEditFlags.Type.class, 6);
+        for (int i = 0; i < asFlags.length; i++) {
+            JImColorEditFlags.Type asFlag = asFlags[i];
+            assertTrue(flags.contains(asFlag));
+        }
+    }
+
+    @Test
+    public void getFlagsValue() {
+        assertEquals(6, Flag.getAsValue(JImColorEditFlags.Type.NoAlpha, JImColorEditFlags.Type.NoPicker));
+    }
+}

--- a/core/test/org/ice1000/jimgui/flag/JImFlagsTest.java
+++ b/core/test/org/ice1000/jimgui/flag/JImFlagsTest.java
@@ -1,0 +1,140 @@
+package org.ice1000.jimgui.flag;
+
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JImFlagsTest {
+
+    @Test
+    public void backendFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImBackendFlags.Type.values(), JImBackendFlags.class);
+    }
+
+    @Test
+    public void comboFlagst() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImComboFlags.Type.values(), JImComboFlags.class);
+    }
+
+    @Test
+    public void conditionFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImCondition.Type.values(), JImCondition.class);
+    }
+
+    @Test
+    public void configFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImConfigFlags.Type.values(), JImConfigFlags.class);
+    }
+
+    @Test
+    public void directionFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImDirection.Type.values(), JImDirection.class, -1);
+    }
+
+    @Test
+    public void drawCornerFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImDrawCornerFlags.Type.values(), JImDrawCornerFlags.class);
+    }
+
+    @Test
+    public void drawListFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImDrawListFlags.Type.values(), JImDrawListFlags.class);
+    }
+
+    @Test
+    public void focusedFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImFocusedFlags.Type.values(), JImFocusedFlags.class);
+    }
+
+    @Test
+    public void fontAtlasFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImFontAtlasFlags.Type.values(), JImFontAtlasFlags.class);
+    }
+
+    @Test
+    public void hoveredFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImHoveredFlags.Type.values(), JImHoveredFlags.class);
+    }
+
+    @Test
+    public void inputTextFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImInputTextFlags.Type.values(), JImInputTextFlags.class);
+    }
+
+    @Test
+    public void mouseIndexesFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImMouseIndexes.Type.values(), JImMouseIndexes.class, -1);
+    }
+
+    @Test
+    public void selectableFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImSelectableFlags.Type.values(), JImSelectableFlags.class);
+    }
+
+    @Test
+    public void tabBarFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImTabBarFlags.Type.values(), JImTabBarFlags.class);
+    }
+
+    @Test
+    public void tabItemFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImTabItemFlags.Type.values(), JImTabItemFlags.class);
+    }
+
+    @Test
+    public void textEditFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImTextEditFlags.Type.values(), JImTextEditFlags.class);
+    }
+
+    @Test
+    public void treeNodeFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImTreeNodeFlags.Type.values(), JImTreeNodeFlags.class);
+    }
+
+    @Test
+    public void windowFlags() throws NoSuchFieldException, InstantiationException, IllegalAccessException {
+        checkFlags(JImWindowFlags.Type.values(), JImWindowFlags.class);
+    }
+
+    public static void checkFlags(Enum[] flags, Class<?> flagsClazz) throws NoSuchFieldException,
+            IllegalAccessException, InstantiationException {
+        checkFlags(flags, flagsClazz, 0);
+    }
+
+    public static void checkFlags(Enum[] flags, Class<?> flagsClazz, int flag0Value)
+            throws NoSuchFieldException, IllegalAccessException, InstantiationException {
+        // No Such Flag
+        Flag flags0 = (Flag) flags[0];
+        assertEquals(flag0Value, flags0.get());
+
+        // Do a reverse lookup and make sure we have the same amount of types as the original flags class
+        Field[] declaredFields = flagsClazz.getDeclaredFields();
+
+        for (Field declaredField : declaredFields) {
+            String name = declaredField.getName();
+            boolean foundFlag = false;
+            for (Enum flag : flags) {
+                if (flag.name().equals(name)) {
+                    foundFlag = true;
+                    break;
+                }
+            }
+            assertTrue(foundFlag);
+        }
+
+        // Start at one, since the first value should be no such flag
+        for (int i = 1; i < flags.length; i++) {
+            Enum enumFlag = flags[i];
+            Flag flagType = (Flag) enumFlag;
+            int flagTypeInt = flagType.get();
+
+            Field field = flagsClazz.getField(enumFlag.name());
+
+            int flagClazzInt = field.getInt(null);
+            assertEquals(flagClazzInt, flagTypeInt);
+        }
+    }
+}


### PR DESCRIPTION
Closes #37.

This feature / enhancement  was to add some object oriented style programming / human readable with 
what is normally bit-wise permissions using a integer to hold all the bits that represent some flag based on its bit-place which in turn is a value that is "|" ORed with the single integer containing all the flags. 

Added
- Flags interface with one single method `int get()` and helper methods for checking flags
as well as retrieving them for human readable viewing in the interface
- Each class that held int constants representing a flag now has a Type subclass
which is an enum that implements Flag
- Test cases were added. The test will make sure the Flags methods are working and do a reverse lookup and make sure that the developer did not miss any permissions mirroring in the Type class.

Notes: All classes that have flags must have matching Type to pass, all flags must be mappable  to a class containing the flag constant. Test case performance/design was to provide simplicity in copy - pasta. A Nothing field was added to all classes that did not have a `int Nothing = 0;` to ensure uniformity between flags that did not have a None. Default or Nothing already.