### PR TITLE
Add info regarding how to include using maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ dependencies {
 ## Maven
 
 ```xml
+<repositories>
+  <repository>
+    <id>jcenter</id>
+    <url>https://jcenter.bintray.com</url>
+  </repository>
+</repositories>
+
 <dependency>
   <groupId>org.ice1000.jimgui</groupId>
   <!-- basic functionality -->


### PR DESCRIPTION
The dependency is in JCenter repo, the repo must be added. Information on how to add the repo is added to the README.md

Fix #53