### PR TITLE
Add "Automatic-Module-Name" to gradle.build.kt

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ First you need to make sure you have `cmake` newer than 3.14 and the following s
 	+ `pkg-config`
 	+ `libglfw3-dev`
 + For Windows (\>= XP)
-	+ Visual Studio 2019 with `msbuild`
+	+ Visual Studio 2019 with `msbuild` (needs to be on PATH)
 	+ DirectX 9 Libraries (should be pre-installed on Windows or with Visual Studio)
-	+ DirectX SDK
+	+ [DirectX SDK](https://www.microsoft.com/en-us/download/details.aspx?id=6812))
 + For Mac OS X
 	+ Everything needed on Linux
 	+ `Cocoa`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,8 +31,13 @@ allprojects {
 			isDebug = !isCI
 			compilerArgs.add("-Xlint:unchecked")
 		}
+	}
+		
+	tasks.jar {
 		manifest {
-			attributes("Automatic-Module-Name" to "ice1000.jimgui")
+			attributes(
+				 "Automatic-Module-Name" to "ice1000.jimgui"
+			)
 		}
 	}
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,9 @@ allprojects {
 			isDebug = !isCI
 			compilerArgs.add("-Xlint:unchecked")
 		}
+		manifest {
+			attributes("Automatic-Module-Name" to "ice1000.jimgui")
+		}
 	}
 
 	val sourcesJar = task<Jar>("sourcesJar") {


### PR DESCRIPTION
Module name is set to `ice1000.jimgui`, change it accordingly if you will. 

**Beware: I have no experience with Gradle, however I managed to use the same technique I used here to produce an automatically named module a few moments ago. I cannot build this project in Eclipse, so I couldn't test. Please test the proposed change and confirm it is working (by opening the jar file and navigating to META-INF > MANIFEST.MF file, check if it contains the string `
Automatic-Module-Name: ice1000.jimgui` on local before merging. Thank you.** 

Fix #55