### PR TITLE
rename TabMinWidthForUnselectedCloseButton to TabMinWidthForCloseButton

### DIFF
--- a/buildSrc/src/GenStyleTask.kt
+++ b/buildSrc/src/GenStyleTask.kt
@@ -63,7 +63,7 @@ open class GenStyleTask : GenTask("JImGuiStyleGen", "imgui_style") {
 			"float" to "LogSliderDeadzone",
 			"float" to "TabRounding",
 			"float" to "TabBorderSize",
-			"float" to "TabMinWidthForUnselectedCloseButton",
+			"float" to "TabMinWidthForCloseButton",
 			"float" to "MouseCursorScale",
 			"float" to "CurveTessellationTol",
 			"float" to "CircleSegmentMaxError",


### PR DESCRIPTION
TabMinWidthForUnselectedCloseButton was renamed to TabMinWidthForCloseButton in version 1.79