### PR TITLE
Support Apple Silicon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "core/jni/glfw"]
+	path = core/jni/glfw
+	url = https://github.com/glfw/glfw

--- a/core/jni/CMakeLists.txt
+++ b/core/jni/CMakeLists.txt
@@ -58,6 +58,9 @@ else ()
 
     mark_as_advanced(COCOA_LIBRARY GLUT_LIBRARY OpenGL_LIBRARY)
 
+    # Compiled universal library to support both x86_64 and arm64
+    set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
+
     # Fix _CVDisplayLinkRelease
     set(CMAKE_SHARED_LINK_FLAGS "${CMAKE_SHARED_LINK_FLAGS} -framework IOKit -framework CoreVideo -framework CoreFoundation")
     set(EXTRA_LIBS ${COCOA_LIBRARY} ${GLUT_LIBRARY} ${OpenGL_LIBRARY})

--- a/core/jni/CMakeLists.txt
+++ b/core/jni/CMakeLists.txt
@@ -36,18 +36,10 @@ if (WIN32)
 else ()
   find_package(OpenGL REQUIRED)
   find_package(PkgConfig REQUIRED)
-  find_package(glfw3 REQUIRED)
-
-  pkg_search_module(GLFW REQUIRED glfw3)
-
-  if (glfw3_FOUND)
-    message(STATUS "GLFW_INCLUDE_DIRS=${GLFW_INCLUDE_DIRS}")
-  endif ()
 
   set(IMGUI_IMPL project/impl_header.cpp impl/imgui_impl_glfw.cpp impl/imgui_impl_opengl3.cpp impl/gl3w.c project/glfw_impl.cpp)
   include_directories(${GLFW_INCLUDE_DIRS})
 
-  set(TARGET_LINK_LIBS ${GLFW_STATIC_LIBRARIES})
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format-security -O3")
 
   if (APPLE)
@@ -61,10 +53,26 @@ else ()
     # Compiled universal library to support both x86_64 and arm64
     set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
 
+    # Statically linking glfw
+    set(OLD_BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS}")
+    set(BUILD_SHARED_LIBS "OFF")
+    set(GLFW_NATIVE_API 1)
+    add_subdirectory(glfw)
+    set(BUILD_SHARED_LIBS "${OLD_BUILD_SHARED_LIBS}")
+    list(APPEND TARGET_LINK_LIBS glfw)
+
     # Fix _CVDisplayLinkRelease
     set(CMAKE_SHARED_LINK_FLAGS "${CMAKE_SHARED_LINK_FLAGS} -framework IOKit -framework CoreVideo -framework CoreFoundation")
     set(EXTRA_LIBS ${COCOA_LIBRARY} ${GLUT_LIBRARY} ${OpenGL_LIBRARY})
     list(APPEND TARGET_LINK_LIBS ${EXTRA_LIBS})
+  else()
+    find_package(glfw3 REQUIRED)
+    pkg_search_module(GLFW REQUIRED glfw3)
+
+    if (glfw3_FOUND)
+      message(STATUS "GLFW_INCLUDE_DIRS=${GLFW_INCLUDE_DIRS}")
+    endif ()
+    set(TARGET_LINK_LIBS ${GLFW_STATIC_LIBRARIES})
   endif ()
 endif ()
 

--- a/core/jni/project/glfw_impl.cpp
+++ b/core/jni/project/glfw_impl.cpp
@@ -19,6 +19,7 @@
 #include <org_ice1000_jimgui_JImGui.h>
 #include <org_ice1000_jimgui_JImTextureID.h>
 
+#include <string>
 #include <basics.hpp>
 #include <impl_header.h>
 
@@ -36,8 +37,6 @@
   #define OPENGL_MAJOR_VERSION 3
   #define OPENGL_MINOR_VERSION 0
 #endif
-
-#include <string>
 
 static void glfw_error_callback(int error, Ptr<const char> description) {
   fprintf(stderr, "JImGui Error %d: %s\n", error, description);

--- a/core/jni/project/imgui_ext.h
+++ b/core/jni/project/imgui_ext.h
@@ -81,20 +81,20 @@ namespace ImGui {
 	          ComVec4 color = ImGui::GetStyle().Colors[ImGuiCol_Button],
 	          float rounding = 0.0f,
 	          float thickness = 1.0f,
-	          int rounding_corners_flags = ImDrawCornerFlags_All) -> void;
+	          int rounding_corners_flags = ImDrawFlags_RoundCornersAll) -> void;
 	/// if @param thickness < 0, rect will be filled
 	auto DrawRect(ComVec4 border,
 	              ComVec4 color = ImGui::GetStyle().Colors[ImGuiCol_Button],
 	              float rounding = 0.0f,
 	              float thickness = 1.0f,
-	              int rounding_corners_flags = ImDrawCornerFlags_All) -> void;
+	              int rounding_corners_flags = ImDrawFlags_RoundCornersAll) -> void;
 	/// if @param thickness < 0, rect will be filled
 	auto DrawRect(ComVec2 pos,
 	              ComVec2 size,
 	              ComVec4 color = ImGui::GetStyle().Colors[ImGuiCol_Button],
 	              float rounding = 0.0f,
 	              float thickness = 1.0f,
-	              int rounding_corners_flags = ImDrawCornerFlags_All) -> void;
+	              int rounding_corners_flags = ImDrawFlags_RoundCornersAll) -> void;
 
 	auto BufferingBar(float value,
 	                  ComVec2 size,


### PR DESCRIPTION
### Summary
- Compile universal library for x86_64 and arm64
- Statically linking `glfw` into `libjimgui.dylib`
- Fix usage of obsolete enums (`ImDrawCornerFlags_All`)

### Needs more tests
Changes have been tested under macOS Big Sur 11.2.3 with M1 chip.
But I don't have an intel-mac so can anyone help me?